### PR TITLE
Fix sniff by respecting addFixableError return value

### DIFF
--- a/src/AbstractOrFinalClassesOnly/Sniffs/AbstractOrFinalSniff.php
+++ b/src/AbstractOrFinalClassesOnly/Sniffs/AbstractOrFinalSniff.php
@@ -29,13 +29,12 @@ final class AbstractOrFinalSniff implements Sniff
         $this->fixer = $file->fixer;
         $this->position = $position;
 
-        if (!$file->findPrevious($this->tokens, $position)) {
-            $file->addFixableError(
+        if (!$file->findPrevious($this->tokens, $position) && $file->addFixableError(
                 'All classes should be declared using either the "abstract" or "final" keyword',
                 $position - 1,
                 self::class
-            );
-            $this->fix();
+            )) {
+                $this->fix();
         }
     }
 


### PR DESCRIPTION
Fixes exception that is thrown on classes without a `final` or `abstract`:

```
PHP Fatal error:  Uncaught PHP_CodeSniffer\Exceptions\RuntimeException: Undefined index: scope_opener in \vendor\slevomat\coding-standard\SlevomatCodingStandard\Helpers\ClassHelper.php on line 56 in \vendor\squizlabs\php_codesniffer\src\Runner.php:606
Stack trace:
#0 \vendor\slevomat\coding-standard\SlevomatCodingStandard\Helpers\ClassHelper.php(56): PHP_CodeSniffer\Runner->handleErrors(8, 'Undefined index...', '<dir>\\...', 56, Array)
#1 \vendor\slevomat\coding-standard\SlevomatCodingStandard\Helpers\ClassHelper.php(74): SlevomatCodingStandard\Helpers\ClassHelper::getName(Object(PHP_CodeSniffer\Files\LocalFile), 1247)
#2 \vendor\slevomat\coding-standard\SlevomatCodingStan in \vendor\squizlabs\php_codesniffer\src\Runner.php on line 606
```